### PR TITLE
Rounding modes and per-call overflow override for conversions

### DIFF
--- a/src/Microfloat.jl
+++ b/src/Microfloat.jl
@@ -37,7 +37,7 @@ end
 function Base.show(io::IO, x::T) where T<:Microfloat
     show_typeinfo = get(IOContext(io), :typeinfo, nothing) != T
     show_typeinfo && print(io, repr(T), "(")
-    print(io, Float64(x))
+    print(io, decimal_string(x))
     show_typeinfo && print(io, ")")
     return nothing
 end
@@ -149,9 +149,13 @@ Base.typemin(::Type{T}) where T<:Microfloat =
     sign_bits(T) == 0 ? zero(T) : hasinf(T) ? -inf(T) : -floatmax(T)
 Base.typemax(::Type{T}) where T<:Microfloat = hasinf(T) ? inf(T) : floatmax(T)
 
-Base.floatmin(::Type{T}) where T<:Microfloat =
-    significand_bits(T) == 0 ? reinterpret(T, 0x00) :
-    reinterpret(T, UInt8(0x01) << significand_bits(T))
+function Base.floatmin(::Type{T}) where T<:Microfloat
+    significand_bits(T) == 0 && return reinterpret(T, 0x00)
+    bits = UInt8(0x01) << significand_bits(T)
+    hasinf(T) && bits == reinterpret(Unsigned, inf(T)) &&
+        throw(DomainError(T, "$T has no normal values"))
+    return reinterpret(T, bits)
+end
 
 Base.zero(::Type{T}) where T<:Microfloat = reinterpret(T, 0x00)
 Base.one(::Type{T}) where T<:Microfloat = T(true)

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -20,7 +20,7 @@ or as a per-call keyword.
 
 The table above describes the *default-mode* (`RoundNearest`) behavior.
 Directed modes like `RoundToZero` saturate per IEEE-754 regardless of
-policy — see [`apply_overflow_policy`](@ref).
+policy.
 
 See also [`SAT`](@ref).
 

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -1,15 +1,28 @@
 abstract type OverflowPolicy end
 
+struct Overflowing <: OverflowPolicy end
+
+struct Saturating <: OverflowPolicy end
+
 """
-Overflow policy that maps out-of-range inputs to a sentinel: `±Inf` if `T` has
-infinity, else `NaN` if `T` has NaN, else a `DomainError`.
+    OVF
+
+Policy that maps numeric overflow to a sentinel — `±Inf` when the format
+has infinity, otherwise `NaN` when it has NaN, otherwise a `DomainError`.
+
+Pass directly as the value of `overflow=` in `@microfloat` declarations
+or as a per-call keyword.
 
 | Input                  | [`IEEE`](@ref) | [`NanOnlyAllOnes`](@ref) | [`FiniteOnly`](@ref) |
 | ---------------------- | -------------- | ------------------------ | -------------------- |
 | `isnan(x)`             | NaN            | NaN                      | Error                |
 | `abs(x) > floatmax(T)` | ±Inf           | NaN                      | Error                |
 
-See also [`SAT`](@ref).
+The table above describes the *default-mode* (`RoundNearest`) behavior.
+Directed modes like `RoundToZero` saturate per IEEE-754 regardless of
+policy — see [`apply_overflow_policy`](@ref).
+
+See also [`Saturating`](@ref), [`SAT`](@ref).
 
 # Examples
 ```jldoctest
@@ -17,20 +30,28 @@ julia> @microfloat OverflowingFloat8 exponent=4 significand=3 overflow=Microfloa
 
 julia> OverflowingFloat8(10000)
 OverflowingFloat8(Inf)
+
+julia> Float8_E4M3(10000; overflow=Microfloats.OVF)
+Float8_E4M3(Inf)
 ```
 """
-abstract type OVF <: OverflowPolicy end
+const OVF = Overflowing()
 
 """
-Overflow policy that clamps out-of-range inputs to `±floatmax(T)`. NaN inputs
-pass through if `T` has NaN, else throw a `DomainError`.
+    SAT
+
+Policy that clamps numeric overflow to `±floatmax(T)`. NaN inputs pass
+through if `T` has NaN, else throw a `DomainError`.
+
+Pass directly as the value of `overflow=` in `@microfloat` declarations
+or as a per-call keyword.
 
 | Input                  | [`IEEE`](@ref) | [`NanOnlyAllOnes`](@ref) | [`FiniteOnly`](@ref) |
 | ---------------------- | -------------- | ------------------------ | -------------------- |
 | `isnan(x)`             | NaN            | NaN                      | Error                |
 | `abs(x) > floatmax(T)` | ±floatmax      | ±floatmax                | ±floatmax            |
 
-See also [`OVF`](@ref).
+See also [`Overflowing`](@ref), [`OVF`](@ref).
 
 # Examples
 ```jldoctest
@@ -38,87 +59,125 @@ julia> @microfloat SaturatingFloat8 exponent=4 significand=3 overflow=Microfloat
 
 julia> SaturatingFloat8(10000)
 SaturatingFloat8(240.0)
+
+julia> Float8_E4M3(10000; overflow=Microfloats.SAT)
+Float8_E4M3(240.0)
 ```
 """
-abstract type SAT <: OverflowPolicy end
+const SAT = Saturating()
 
 """
-    overflow_policy(::Type{<:Microfloat}) -> Type{<:OverflowPolicy}
+    overflow_policy(::Type{<:Microfloat}) -> OverflowPolicy
 
-Return the overflow policy registered by [`@microfloat`](@ref) — either
-[`OVF`](@ref) (out-of-range inputs go to a sentinel) or [`SAT`](@ref)
-(out-of-range inputs clamp to `±floatmax`).
+Return the overflow policy *instance* registered by
+[`@microfloat`](@ref) — typically [`OVF`](@ref) or [`SAT`](@ref). Sets
+the default for `overflow=...` at every conversion call site for this
+type; override per call with the `overflow` keyword.
 
 # Examples
 ```jldoctest
 julia> Microfloats.overflow_policy(Float8_E5M2)
-Microfloats.OVF
+Microfloats.Overflowing()
 
 julia> Microfloats.overflow_policy(Float4_E2M1FN)
-Microfloats.SAT
+Microfloats.Saturating()
 ```
 """
 overflow_policy(::Type{T}) where T<:Microfloat =
     error("$T must define `Microfloats.overflow_policy(::Type{$T})`")
 
-function rshift_round_to_even(x::UInt16, n::Int)
+function rshift_round_to_even(x::T, n::Int) where T<:Unsigned
     n <= 0 && return x >> n
-    x_32 = UInt32(x)
-    lower = x_32 & ((UInt32(1) << n) - UInt32(1))
-    half = UInt32(1) << (n - 1)
-    up = (lower > half) | ((lower == half) & (((x_32 >> n) & UInt32(1)) == UInt32(1)))
-    UInt16((x_32 >> n) + (up ? 1 : 0))
+    n > 8 * sizeof(T) && return zero(T)
+    mask = (T(1) << n) - T(1)
+    half = T(1) << (n - 1)
+    lower = x & mask
+    up = (lower > half) | ((lower == half) & (((x >> n) & T(1)) == T(1)))
+    (x >> n) + (up ? T(1) : T(0))
 end
 
-is_outside_floatmax(xb::BFloat16, ::Type{T}) where T<:Microfloat =
-    reinterpret(Unsigned, abs(xb)) > reinterpret(Unsigned, BFloat16(floatmax(T)))
+function rshift_round_ties_away(x::T, n::Int) where T<:Unsigned
+    n <= 0 && return x >> n
+    n > 8 * sizeof(T) && return zero(T)
+    mask = (T(1) << n) - T(1)
+    half = T(1) << (n - 1)
+    lower = x & mask
+    up = lower >= half
+    (x >> n) + (up ? T(1) : T(0))
+end
+
+rshift_truncate(x::T, n::Int) where T<:Unsigned = x >> n
+
+function rshift_round_up_magnitude(x::T, n::Int) where T<:Unsigned
+    n <= 0 && return x >> n
+    mask = (T(1) << n) - T(1)
+    has_low_bits = (x & mask) != T(0)
+    (x >> n) + (has_low_bits ? T(1) : T(0))
+end
+
+is_outside_floatmax(x::Float32, ::Type{T}) where T<:Microfloat =
+    reinterpret(Unsigned, abs(x)) > reinterpret(Unsigned, Float32(floatmax(T)))
 clamp_floatmax(x::T) where T<:Microfloat = signbit(x) ? -floatmax(T) : floatmax(T)
 clamp_inf(x::T) where T<:Microfloat = signbit(x) ? -inf(T) : inf(T)
 
-function _finalize(x::T, xb::BFloat16, ::Type{SAT}) where T<:Microfloat
-    if isnan(xb)
-        return hasnan(T) ? nan(T) : throw(DomainError(xb, "$T has no NaN"))
-    elseif isinf(xb) || is_outside_floatmax(xb, T)
+@inline mode_overflows_to_inf(::RoundingMode{:Nearest},          ::Bool) = true
+@inline mode_overflows_to_inf(::RoundingMode{:NearestTiesAway},  ::Bool) = true
+@inline mode_overflows_to_inf(::RoundingMode{:FromZero},         ::Bool) = true
+@inline mode_overflows_to_inf(::RoundingMode{:ToZero},           ::Bool) = false
+@inline mode_overflows_to_inf(::RoundingMode{:Up},   signbit::Bool) = !signbit
+@inline mode_overflows_to_inf(::RoundingMode{:Down}, signbit::Bool) = signbit
+
+function apply_overflow_policy(x::T, xf::Float32, mode::RoundingMode, ::Overflowing) where T<:Microfloat
+    if isnan(xf)
+        return hasnan(T) ? nan(T) : throw(DomainError(xf, "$T has no NaN"))
+    elseif isinf(xf) || is_outside_floatmax(xf, T)
+        if mode_overflows_to_inf(mode, signbit(xf))
+            return hasinf(T) ? clamp_inf(x) :
+                   hasnan(T) ? nan(T) :
+                   throw(DomainError(xf, "$T has no overflow sentinel; use overflow=SAT"))
+        else
+            return clamp_floatmax(x)
+        end
+    else
+        return x
+    end
+end
+
+function apply_overflow_policy(x::T, xf::Float32, ::RoundingMode, ::Saturating) where T<:Microfloat
+    if isnan(xf)
+        return hasnan(T) ? nan(T) : throw(DomainError(xf, "$T has no NaN"))
+    elseif isinf(xf) || is_outside_floatmax(xf, T)
         return clamp_floatmax(x)
     else
         return x
     end
 end
 
-function _finalize(x::T, xb::BFloat16, ::Type{OVF}) where T<:Microfloat
-    if isnan(xb)
-        return hasnan(T) ? nan(T) : throw(DomainError(xb, "$T has no NaN"))
-    elseif isinf(xb) || is_outside_floatmax(xb, T)
-        return hasinf(T) ? clamp_inf(x) :
-               hasnan(T) ? nan(T) :
-               throw(DomainError(xb, "$T has no overflow sentinel; declare the type with overflow=SAT"))
-    else
-        return x
-    end
-end
-
-function (::Type{T})(x::BFloat16) where T<:Microfloat
+# All rounding modes share this body; the `rshift` helper varies.
+function _round_to_microfloat(::Type{T}, x::Float32, rshift::F,
+                              mode::RoundingMode, policy::OverflowPolicy
+                              ) where {T<:Microfloat, F}
     if sign_bits(T) == 0 && signbit(x)
         throw(DomainError(x, "negative input to unsigned $T"))
     end
     iszero(x) && return signbit(x) ? -zero(T) : zero(T)
 
-    bf16_exp  = Int((reinterpret(Unsigned, x) >> 7) & 0x00ff)
-    bf16_frac = UInt16(reinterpret(Unsigned, x) & 0x007f)
+    f32_raw  = reinterpret(UInt32, x)
+    f32_exp  = Int((f32_raw >> 23) & UInt32(0x000000ff))
+    f32_frac = f32_raw & UInt32(0x007fffff)
 
-    sig8 = bf16_exp == 0 ? bf16_frac : (0x0080 | bf16_frac)
-    true_exp = bf16_exp == 0 ? -126 : (bf16_exp - 127)
+    sig24 = f32_exp == 0 ? f32_frac : (UInt32(0x00800000) | f32_frac)
+    true_exp = f32_exp == 0 ? -126 : (f32_exp - 127)
     t_exp = true_exp + exponent_bias(T)
 
-    t_raw = 0x00
     if t_exp <= 0
         # Subnormal path in target format
-        shift = t_exp + significand_bits(T) - 8
-        sub_q = rshift_round_to_even(sig8, -shift)
-        max_frac = UInt16((1 << significand_bits(T)) - 1)
+        shift = t_exp + significand_bits(T) - 24
+        sub_q = rshift(sig24, -shift)
+        max_frac = UInt32((1 << significand_bits(T)) - 1)
         if sub_q == 0
             t_raw = 0x00
-        elseif sub_q == (UInt16(1) << significand_bits(T))
+        elseif sub_q == (UInt32(1) << significand_bits(T))
             t_raw = UInt8(1) << significand_bits(T)
         else
             sub_q = min(sub_q, max_frac)
@@ -126,19 +185,17 @@ function (::Type{T})(x::BFloat16) where T<:Microfloat
         end
     else
         # Normal path in target format
-        shift = 7 - significand_bits(T)
-        total = shift >= 0 ? rshift_round_to_even(sig8, shift) : (sig8 << (-shift))
+        shift = 23 - significand_bits(T)
+        total = rshift(sig24, shift)
         if total == 0
             t_raw = 0x00
         else
-            t_exp_rounded = t_exp + (total >> (significand_bits(T) + 1))
+            t_exp_rounded = t_exp + Int(total >> (significand_bits(T) + 1))
             max_exp = (1 << exponent_bits(T)) - 1
             if t_exp_rounded > max_exp
+                t_exp_rounded = max_exp
                 if !hasinf(T)
-                    t_exp_rounded = max_exp
-                    total = (UInt16(1) << significand_bits(T)) | UInt16((1 << significand_bits(T)) - 1)
-                else
-                    t_exp_rounded = max_exp
+                    total = (UInt32(1) << significand_bits(T)) | UInt32((1 << significand_bits(T)) - 1)
                 end
             end
             frac_field = UInt8(total) & UInt8((1 << significand_bits(T)) - 1)
@@ -146,12 +203,49 @@ function (::Type{T})(x::BFloat16) where T<:Microfloat
         end
     end
 
-    t_raw |= (reinterpret(Unsigned, x) >> 15 % UInt8) << (exponent_bits(T) + significand_bits(T)) & sign_mask(T)
+    t_raw |= (((f32_raw >> 31) % UInt8) << (exponent_bits(T) + significand_bits(T))) & sign_mask(T)
 
-    return _finalize(reinterpret(T, t_raw), x, overflow_policy(T))
+    return apply_overflow_policy(reinterpret(T, t_raw), x, mode, policy)
 end
 
-(::Type{T})(x::Number) where {T<:Microfloat} = T(BFloat16(x))
+(::Type{T})(x::Float32, mode::RoundingMode{:Nearest};
+            overflow::OverflowPolicy = overflow_policy(T)) where T<:Microfloat =
+    _round_to_microfloat(T, x, rshift_round_to_even, mode, overflow)
+(::Type{T})(x::Float32, mode::RoundingMode{:NearestTiesAway};
+            overflow::OverflowPolicy = overflow_policy(T)) where T<:Microfloat =
+    _round_to_microfloat(T, x, rshift_round_ties_away, mode, overflow)
+(::Type{T})(x::Float32, mode::RoundingMode{:ToZero};
+            overflow::OverflowPolicy = overflow_policy(T)) where T<:Microfloat =
+    _round_to_microfloat(T, x, rshift_truncate, mode, overflow)
+(::Type{T})(x::Float32, mode::RoundingMode{:FromZero};
+            overflow::OverflowPolicy = overflow_policy(T)) where T<:Microfloat =
+    _round_to_microfloat(T, x, rshift_round_up_magnitude, mode, overflow)
+
+# RoundUp/RoundDown are sign-dependent: "toward +∞" rounds the magnitude up
+# for positive inputs but truncates the magnitude for negative inputs (which
+# moves the value toward zero, i.e., closer to +∞). RoundDown is the mirror.
+(::Type{T})(x::Float32, mode::RoundingMode{:Up};
+            overflow::OverflowPolicy = overflow_policy(T)) where T<:Microfloat =
+    signbit(x) ? _round_to_microfloat(T, x, rshift_truncate,           mode, overflow) :
+                 _round_to_microfloat(T, x, rshift_round_up_magnitude, mode, overflow)
+(::Type{T})(x::Float32, mode::RoundingMode{:Down};
+            overflow::OverflowPolicy = overflow_policy(T)) where T<:Microfloat =
+    signbit(x) ? _round_to_microfloat(T, x, rshift_round_up_magnitude, mode, overflow) :
+                 _round_to_microfloat(T, x, rshift_truncate,           mode, overflow)
+
+# Errors on unsupported modes instead of recursing through the Real-level fallback below.
+(::Type{T})(x::Float32, mode::RoundingMode;
+            overflow::OverflowPolicy = overflow_policy(T)) where T<:Microfloat =
+    throw(ArgumentError("$T does not support rounding mode $mode"))
+
+# `Real` (not `Number`) avoids colliding with Base's
+# `(::Type{T})(::Real, ::RoundingMode) where T<:AbstractFloat`.
+(::Type{T})(x::Real;
+            overflow::OverflowPolicy = overflow_policy(T)) where T<:Microfloat =
+    T(x, RoundNearest; overflow=overflow)
+(::Type{T})(x::Real, mode::RoundingMode;
+            overflow::OverflowPolicy = overflow_policy(T)) where T<:Microfloat =
+    T(Float32(x), mode; overflow=overflow)
 
 function _to_bfloat16(x::T) where {T<:Microfloat}
     t_raw = reinterpret(UInt8, x)
@@ -174,7 +268,7 @@ function _to_bfloat16(x::T) where {T<:Microfloat}
     bias = exponent_bias(T)
 
     if t_exponent_field == 0 && M > 0 # Subnormal
-        nlz = M - 1 - floor(Int, log2(t_fraction_field))
+        nlz = leading_zeros(t_fraction_field) + M - 16
         t_significand_total = UInt16(t_fraction_field) << (nlz + 1)
         t_true_exponent = -nlz - bias
     else # Normal
@@ -213,7 +307,45 @@ end
 # `@microfloat` adds a new method to `to_bfloat16`
 function to_bfloat16 end
 
-# user can add specialized conversions to `BFloat16` itself
-BFloat16(x::T) where T<:Microfloat = to_bfloat16(x)
+function _format_sci(f64::Float64, n::Int)
+    ax = abs(f64)
+    e = floor(Int, log10(ax))
+    k = n - 1 - e
+    scaled = k >= 0 ? ax * exp10(k) : ax / exp10(-k)
+    m = round(Int, scaled)
+    if m >= 10^n
+        m ÷= 10
+        e += 1
+    end
+    digits = lpad(string(m), n, '0')
+    mantissa = n == 1 ? digits * ".0" : digits[1:1] * "." * digits[2:n]
+    return (signbit(f64) ? "-" : "") * mantissa * "e" * string(e)
+end
 
-(::Type{T})(x::Microfloat) where {T<:AbstractFloat} = T(BFloat16(x))
+# 4 sig digits cover every Microfloat variant. When the rounded value isn't
+# Float64-representable, Ryu's shortest form blows up
+# (e.g. "2.9999999999999998e-40"); detect via length and reformat.
+function _shortest_decimal_string(x::T) where T<:Microfloat
+    isnan(x) && return "NaN"
+    isinf(x) && return signbit(x) ? "-Inf" : "Inf"
+    iszero(x) && return signbit(x) ? "-0.0" : "0.0"
+    f64 = Float64(x)
+    for ndig in 1:4
+        rounded = round(f64, sigdigits=ndig)
+        T(rounded) === x || continue
+        s = string(rounded)
+        length(s) <= ndig + 8 && return s
+        return _format_sci(f64, ndig)
+    end
+    return string(f64)
+end
+
+# `@microfloat` adds a new method to `decimal_string`
+function decimal_string end
+
+# Every Microfloat is exactly representable in BFloat16 (M ≤ 7, E ≤ 8), so
+# widening through BFloat16 is lossless.
+BFloat16(x::T) where T<:Microfloat = to_bfloat16(x)
+(::Type{Float32})(x::Microfloat) = Float32(BFloat16(x))
+(::Type{Float64})(x::Microfloat) = Float64(BFloat16(x))
+(::Type{Float16})(x::Microfloat) = Float16(BFloat16(x))

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -22,7 +22,7 @@ The table above describes the *default-mode* (`RoundNearest`) behavior.
 Directed modes like `RoundToZero` saturate per IEEE-754 regardless of
 policy — see [`apply_overflow_policy`](@ref).
 
-See also [`Saturating`](@ref), [`SAT`](@ref).
+See also [`SAT`](@ref).
 
 # Examples
 ```jldoctest
@@ -51,7 +51,7 @@ or as a per-call keyword.
 | `isnan(x)`             | NaN            | NaN                      | Error                |
 | `abs(x) > floatmax(T)` | ±floatmax      | ±floatmax                | ±floatmax            |
 
-See also [`Overflowing`](@ref), [`OVF`](@ref).
+See also [`OVF`](@ref).
 
 # Examples
 ```jldoctest

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -322,30 +322,36 @@ function _format_sci(f64::Float64, n::Int)
     return (signbit(f64) ? "-" : "") * mantissa * "e" * string(e)
 end
 
-# 4 sig digits cover every Microfloat variant. When the rounded value isn't
-# Float64-representable, Ryu's shortest form blows up
-# (e.g. "2.9999999999999998e-40"); detect via length and reformat.
+# Try increasing precision until the rounded decimal round-trips through `T`.
+# 4 sig digits suffices on precision grounds, but near floatmax under an OVF
+# policy the rounded value can land in the NaN sentinel for several ndig in a
+# row — empirically up to 6 (e.g. `_E1M7_NaN(0xfe) == 3.96875`). 9 is generous
+# headroom given the 8-bit-total constraint. When Ryu's shortest form blows up
+# on values not exactly representable in Float64
+# (e.g. "2.9999999999999998e-40"), detect via length and reformat.
 function _shortest_decimal_string(x::T) where T<:Microfloat
     isnan(x) && return "NaN"
     isinf(x) && return signbit(x) ? "-Inf" : "Inf"
     iszero(x) && return signbit(x) ? "-0.0" : "0.0"
     f64 = Float64(x)
-    for ndig in 1:4
+    for ndig in 1:9
         rounded = round(f64, sigdigits=ndig)
         T(rounded) === x || continue
         s = string(rounded)
         length(s) <= ndig + 8 && return s
         return _format_sci(f64, ndig)
     end
-    return string(f64)
+    error("unreachable: no round-tripping decimal in 1:9 sig digits for $T")
 end
 
 # `@microfloat` adds a new method to `decimal_string`
 function decimal_string end
 
 # Every Microfloat is exactly representable in BFloat16 (M ≤ 7, E ≤ 8), so
-# widening through BFloat16 is lossless.
+# widening through BFloat16 is lossless. Base / BFloat16s.jl supply
+# `T(::BFloat16)` for the standard numeric types (Float16/32/64, Int*, BigFloat).
 BFloat16(x::T) where T<:Microfloat = to_bfloat16(x)
-(::Type{Float32})(x::Microfloat) = Float32(BFloat16(x))
-(::Type{Float64})(x::Microfloat) = Float64(BFloat16(x))
-(::Type{Float16})(x::Microfloat) = Float16(BFloat16(x))
+(::Type{T})(x::Microfloat) where T<:Number = T(BFloat16(x))
+# Microfloat → Microfloat: route through Float32 (matches the Real-input path
+# and avoids the BFloat16 intermediate's narrower exponent dynamic range).
+(::Type{T})(x::Microfloat) where T<:Microfloat = T(Float32(x))

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -2,11 +2,13 @@
     @microfloat name [kwargs...]
 
 Declare `name` as a new 8-bit primitive subtype of [`Microfloat`](@ref) and
-register its layout, non-finite encoding, and overflow policy.
+register its layout, non-finite encoding, and *default* overflow policy.
+The default policy is what [`overflow_policy`](@ref) returns; callers
+override per-call with the `overflow=` keyword on the conversion.
 
-Default policy rule: `OVF` when the type has any non-finite sentinel
-(`IEEE` or `NanOnlyAllOnes`), else `SAT` (forced for `FiniteOnly` since no
-sentinel encoding exists).
+Default policy rule: [`OVF`](@ref) when the type has any non-finite
+sentinel ([`IEEE`](@ref) or [`NanOnlyAllOnes`](@ref)), else [`SAT`](@ref)
+(forced for [`FiniteOnly`](@ref) since no sentinel encoding exists).
 
 ## Keyword arguments
 
@@ -14,8 +16,10 @@ sentinel encoding exists).
 - `exponent`: Number of exponent bits: ≥ `1`
 - `significand`: Number of significand / mantissa bits: ≥ `0`
 - `nonfinite`: [`IEEE`](@ref) (default), [`NanOnlyAllOnes`](@ref), or [`FiniteOnly`](@ref).
-- `overflow`: Overflow handling during conversion from other types: [`SAT`](@ref) or [`OVF`](@ref). Default: `OVF` if the type has any
-  non-finite values (`IEEE`, `NanOnlyAllOnes`), otherwise `SAT` (`FiniteOnly`).
+- `overflow`: Default overflow policy *instance* — typically [`SAT`](@ref)
+  or [`OVF`](@ref). Default: `OVF` if the type has any non-finite values
+  (`IEEE`, `NanOnlyAllOnes`), otherwise `SAT` (`FiniteOnly`). Callers can
+  override per call with `T(x; overflow=SAT)`.
 
 ## Examples
 
@@ -91,14 +95,17 @@ macro microfloat(name, kwargs...)
         let lookup = Tuple($_to_bfloat16(reinterpret($T, i % UInt8)) for i in 0:$(2^N - 1))
             $mod.to_bfloat16(x::$T) = lookup[reinterpret(UInt8, x) + 0x0001]
         end
+        let strings = Tuple($_shortest_decimal_string(reinterpret($T, i % UInt8)) for i in 0:$(2^N - 1))
+            $mod.decimal_string(x::$T) = strings[reinterpret(UInt8, x) + 0x0001]
+        end
     end
 end
 
 function _validate_microfloat(T, nonfinite, overflow)
     (nonfinite isa Type && nonfinite <: NonFiniteBehavior) ||
         throw(ArgumentError("@microfloat($T): `nonfinite` must be IEEE, NanOnlyAllOnes, or FiniteOnly, got $nonfinite"))
-    (overflow isa Type && overflow <: OverflowPolicy) ||
-        throw(ArgumentError("@microfloat($T): `overflow` must be SAT or OVF, got $overflow"))
+    (overflow isa OverflowPolicy) ||
+        throw(ArgumentError("@microfloat($T): `overflow` must be an OverflowPolicy instance (e.g. SAT or OVF), got $overflow"))
     nonfinite === FiniteOnly && overflow === OVF &&
         throw(ArgumentError("@microfloat($T): `overflow=OVF` invalid for `nonfinite=FiniteOnly` (no sentinel encoding)"))
     return nothing

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -233,3 +233,18 @@ end
     # Same-type still works.
     @test a + a == Float8_E4M3FN(2.0)
 end
+
+@testset "Microfloat → standard numeric types" begin
+    x = Float8_E4M3(2.0)
+    @test Int(x) === 2
+    @test Int32(x) === Int32(2)
+    @test UInt8(x) === UInt8(2)
+    @test Float64(x) === 2.0
+    @test Float32(x) === 2.0f0
+    @test Float16(x) === Float16(2.0)
+    @test BigFloat(x) == big"2.0"
+    @test one(Float8_E4M3) |> Int === 1
+
+    # Cross-microfloat conversion (T<:Microfloat disambiguator).
+    @test Float8_E5M2(Float8_E4M3FN(2.0)) === Float8_E5M2(2.0)
+end

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -4,7 +4,7 @@
         @test precision(T) == Microfloats.significand_bits(T) + 1
         @test floatmax(T) > zero(T)
         @test isfinite(floatmax(T))
-        @test Microfloats.overflow_policy(T) <: Union{Microfloats.OVF, Microfloats.SAT}
+        @test Microfloats.overflow_policy(T) isa Union{Microfloats.Overflowing, Microfloats.Saturating}
 
         @test signbit(zero(T)) == false
 
@@ -38,6 +38,30 @@
 
     @test widen(Float8_E4M3) == BFloat16
     @test string(Float8_E4M3(1.0)) == "Float8_E4M3(1.0)"
+end
+
+@testset "Precision-aware show (shortest-roundtrip)" begin
+    @test string(Float8_E4M3(0.1))   == "Float8_E4M3(0.1)"     # was 0.1015625
+    @test string(Float8_E5M2(0.1))   == "Float8_E5M2(0.09)"    # was 0.09375
+    @test string(Float4_E2M1FN(1.5)) == "Float4_E2M1FN(1.5)"   # exact
+    @test string(Float8_E5M2(100.0)) == "Float8_E5M2(100.0)"
+    @test string(Float6_E3M2FN(100.0)) == "Float6_E3M2FN(30.0)"  # quantized to nearest representable
+
+    @testset "$T" for T in TYPES
+        used_mask = Microfloats.sign_mask(T) | Microfloats.exponent_mask(T) | Microfloats.significand_mask(T)
+        for u in 0x00:0xff
+            (u & ~used_mask) != 0x00 && continue
+            x = reinterpret(T, u)
+            (isnan(x) || isinf(x)) && continue
+            s = Microfloats.decimal_string(x)
+            @test T(parse(Float64, s)) === x
+        end
+    end
+
+    # Non-finite values use Julia conventions, not the type-suffixed forms.
+    @test Microfloats.decimal_string(nan(Float8_E5M2)) == "NaN"
+    @test Microfloats.decimal_string(inf(Float8_E5M2)) == "Inf"
+    @test Microfloats.decimal_string(-inf(Float8_E5M2)) == "-Inf"
 end
 
 @testset "@microfloat" begin

--- a/test/floatmin.jl
+++ b/test/floatmin.jl
@@ -1,0 +1,26 @@
+# An E=1 microfloat with IEEE non-finite has biased-exponent 1 reserved for
+# Inf/NaN, so the smallest-normal bit pattern (1 << M) coincides with the Inf
+# encoding. `floatmin` must throw a `DomainError` rather than return Inf.
+
+@microfloat _E1M7_IEEE sign=0 exponent=1 significand=7
+@microfloat _E1M7_FN   sign=0 exponent=1 significand=7 nonfinite=FiniteOnly
+@microfloat _E1M7_NaN  sign=0 exponent=1 significand=7 nonfinite=NanOnlyAllOnes
+
+@testset "floatmin on degenerate (no-normals) formats" begin
+    @test_throws DomainError floatmin(_E1M7_IEEE)
+
+    # E=1 without IEEE non-finite still has one normal exponent.
+    @test Float64(floatmin(_E1M7_FN))  == 2.0
+    @test Float64(floatmin(_E1M7_NaN)) == 2.0
+end
+
+@testset "floatmin on shipped types" begin
+    @test Float64(floatmin(Float8_E5M2))    == 2.0^-14
+    @test Float64(floatmin(Float8_E4M3))    == 2.0^-6
+    @test Float64(floatmin(Float8_E3M4))    == 2.0^-2
+    @test Float64(floatmin(Float8_E4M3FN))  == 2.0^-6
+    @test Float64(floatmin(Float4_E2M1FN))  == 1.0
+    @test Float64(floatmin(Float6_E2M3FN))  == 1.0
+    @test Float64(floatmin(Float6_E3M2FN))  == 0.25
+    @test Float64(floatmin(Float8_E8M0FNU)) == 2.0^-127  # M=0 → returns 0x00 pattern
+end

--- a/test/overflow.jl
+++ b/test/overflow.jl
@@ -7,7 +7,7 @@
         @test T(+Inf) == +inf(T)
         @test T(-Inf) == -inf(T)
 
-        big = nextfloat(BFloat16(floatmax(T)))
+        big = nextfloat(Float32(floatmax(T)))
         @test T(+big) == +inf(T)
         @test T(-big) == -inf(T)
     end
@@ -25,7 +25,7 @@ end
         @test isnan(T(+Inf))
         @test isnan(T(-Inf))
 
-        big = nextfloat(BFloat16(floatmax(T)))
+        big = nextfloat(Float32(floatmax(T)))
         @test isnan(T(+big))
         @test isnan(T(-big))
     end
@@ -39,7 +39,7 @@ end
         @test isnan(T(+Inf))
         @test_throws DomainError T(-Inf)
 
-        big = nextfloat(BFloat16(floatmax(T)))
+        big = nextfloat(Float32(floatmax(T)))
         @test isnan(T(big))
     end
 end
@@ -54,7 +54,7 @@ end
         @test T(+Inf) == +floatmax(T)
         @test T(-Inf) == -floatmax(T)
 
-        big = nextfloat(BFloat16(floatmax(T)))
+        big = nextfloat(Float32(floatmax(T)))
         @test T(+big) == +floatmax(T)
         @test T(-big) == -floatmax(T)
     end
@@ -69,7 +69,7 @@ end
     # Float8_E4M3FN but with overflow=SAT (PyTorch/Triton convention).
     # Shows the documented escape hatch for the non-default policy.
     @test overflow_policy(_E4M3FN_SAT) === SAT
-    big = nextfloat(BFloat16(floatmax(_E4M3FN_SAT)))
+    big = nextfloat(Float32(floatmax(_E4M3FN_SAT)))
     @test _E4M3FN_SAT(big) == floatmax(_E4M3FN_SAT)            # SAT: overflow → floatmax
     @test isnan(Float8_E4M3FN(big))                            # OVF: overflow → NaN
     # Bit layout is identical, so reinterpret is a free relabel.

--- a/test/rounding_modes.jl
+++ b/test/rounding_modes.jl
@@ -1,0 +1,129 @@
+@testset "Default mode = RoundNearest" begin
+    @testset "$T" for T in TYPES
+        # Sample a few non-tie values; all three constructors must agree.
+        for v in (0.0f0, 1.0f0, 2.0f0, 0.5f0)
+            sign_bits(T) == 0 && v < 0 && continue
+            @test T(v) === T(v, RoundNearest)
+        end
+    end
+end
+
+@testset "Round-half-to-even ties (Float8_E4M3)" begin
+    # E4M3 spacing in [1,2) is 1/8. Midpoint(1.0, 1.125) = 1.0625.
+    # Mantissa LSB: 1.0 even, 1.125 odd → ties-to-even → 1.0.
+    @test Float8_E4M3(1.0625f0, RoundNearest)         === Float8_E4M3(1.0)
+    @test Float8_E4M3(1.0625f0, RoundNearestTiesAway) === Float8_E4M3(1.125)
+    @test Float8_E4M3(1.0625f0, RoundToZero)          === Float8_E4M3(1.0)
+
+    # Midpoint(1.125, 1.25) = 1.1875.
+    # Mantissa LSB: 1.125 odd, 1.25 even → ties-to-even → 1.25.
+    @test Float8_E4M3(1.1875f0, RoundNearest)         === Float8_E4M3(1.25)
+    @test Float8_E4M3(1.1875f0, RoundNearestTiesAway) === Float8_E4M3(1.25)
+    @test Float8_E4M3(1.1875f0, RoundToZero)          === Float8_E4M3(1.125)
+end
+
+@testset "RoundUp / RoundDown / RoundFromZero (Float8_E4M3)" begin
+    # 1.1 is in (1.0, 1.125), not exactly representable.
+    @test Float8_E4M3( 1.1f0, RoundUp)       === Float8_E4M3( 1.125)
+    @test Float8_E4M3( 1.1f0, RoundDown)     === Float8_E4M3( 1.0)
+    @test Float8_E4M3( 1.1f0, RoundFromZero) === Float8_E4M3( 1.125)
+    # RoundUp on a negative goes toward zero (less negative).
+    @test Float8_E4M3(-1.1f0, RoundUp)       === Float8_E4M3(-1.0)
+    @test Float8_E4M3(-1.1f0, RoundDown)     === Float8_E4M3(-1.125)
+    @test Float8_E4M3(-1.1f0, RoundFromZero) === Float8_E4M3(-1.125)
+    # Exactly representable: every mode is a no-op.
+    for mode in (RoundUp, RoundDown, RoundFromZero)
+        @test Float8_E4M3(1.5f0, mode) === Float8_E4M3(1.5)
+        @test Float8_E4M3(-1.5f0, mode) === Float8_E4M3(-1.5)
+    end
+end
+
+@testset "Unsupported rounding mode errors cleanly" begin
+    # Non-IEEE-754-directed modes (e.g. NearestTiesUp) — we don't support them.
+    # Must error, not recurse.
+    @test_throws ArgumentError Float8_E4M3(1.5f0, RoundNearestTiesUp)
+    @test_throws ArgumentError Float8_E4M3(1.5,   RoundNearestTiesUp)  # Float64 too
+end
+
+@testset "Truncation does not round up (Float4_E2M1FN)" begin
+    # Values: 0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0.
+    @test Float4_E2M1FN(2.5f0,  RoundToZero) === Float4_E2M1FN(2.0)
+    @test Float4_E2M1FN(2.99f0, RoundToZero) === Float4_E2M1FN(2.0)
+    @test Float4_E2M1FN(0.49f0, RoundToZero) === Float4_E2M1FN(0.0)
+end
+
+@testset "Ties-away rounds magnitude up (Float4_E2M1FN)" begin
+    # 2.5 is the midpoint of 2.0 and 3.0. Both ties → away.
+    @test Float4_E2M1FN(2.5f0, RoundNearestTiesAway) === Float4_E2M1FN(3.0)
+    @test Float4_E2M1FN(1.25f0, RoundNearestTiesAway) === Float4_E2M1FN(1.5)
+end
+
+@testset "NaN propagation across modes" begin
+    @testset "$T" for T in (Float8_E5M2, Float8_E4M3, Float8_E4M3FN)
+        for mode in (RoundNearest, RoundNearestTiesAway, RoundToZero)
+            @test isnan(T(NaN32, mode))
+        end
+    end
+end
+
+@testset "IEEE-754 mode-driven overflow" begin
+    # Overflow target depends on the rounding mode, per IEEE-754. Modes that
+    # round toward zero or toward floatmax-on-the-right-side saturate
+    # regardless of type policy; modes that round toward Inf go to Inf when
+    # the format has one.
+    big = nextfloat(Float32(floatmax(Float8_E4M3)))  # E4M3 = IEEE + OVF
+    @test Float8_E4M3( big, RoundNearest)         === +inf(Float8_E4M3)        # mode wants +Inf
+    @test Float8_E4M3(-big, RoundNearest)         === -inf(Float8_E4M3)        # mode wants -Inf
+    @test Float8_E4M3( big, RoundNearestTiesAway) === +inf(Float8_E4M3)
+    @test Float8_E4M3( big, RoundFromZero)        === +inf(Float8_E4M3)
+    @test Float8_E4M3( big, RoundToZero)          === +floatmax(Float8_E4M3)   # mode wants +floatmax
+    @test Float8_E4M3(-big, RoundToZero)          === -floatmax(Float8_E4M3)
+    @test Float8_E4M3( big, RoundUp)              === +inf(Float8_E4M3)        # positive: toward +Inf
+    @test Float8_E4M3(-big, RoundUp)              === -floatmax(Float8_E4M3)   # negative: toward zero
+    @test Float8_E4M3( big, RoundDown)            === +floatmax(Float8_E4M3)   # positive: toward zero
+    @test Float8_E4M3(-big, RoundDown)            === -inf(Float8_E4M3)        # negative: toward -Inf
+end
+
+@testset "SAT policy clamps regardless of mode" begin
+    big = nextfloat(Float32(floatmax(_E4M3FN_SAT)))
+    @test _E4M3FN_SAT(big, RoundNearest)         === floatmax(_E4M3FN_SAT)
+    @test _E4M3FN_SAT(big, RoundNearestTiesAway) === floatmax(_E4M3FN_SAT)
+    @test _E4M3FN_SAT(big, RoundToZero)          === floatmax(_E4M3FN_SAT)
+    @test _E4M3FN_SAT(big, RoundFromZero)        === floatmax(_E4M3FN_SAT)
+    @test _E4M3FN_SAT(big, RoundUp)              === floatmax(_E4M3FN_SAT)
+end
+
+@testset "Overflow policy keyword override" begin
+    big = nextfloat(Float32(floatmax(Float8_E4M3FN)))
+    # Default policy for E4M3FN is OVF → NaN under RoundNearest.
+    @test isnan(Float8_E4M3FN(big, RoundNearest))
+    # Override to SAT for one call: clamp instead.
+    @test Float8_E4M3FN(big, RoundNearest; overflow=SAT) === floatmax(Float8_E4M3FN)
+    # No-mode entry also honors the keyword.
+    @test Float8_E4M3FN(big; overflow=SAT) === floatmax(Float8_E4M3FN)
+end
+
+@testset "Negative inputs (signed types)" begin
+    # Tie at -1.0625: away-from-zero means more negative.
+    @test Float8_E4M3(-1.0625f0, RoundNearest)         === Float8_E4M3(-1.0)
+    @test Float8_E4M3(-1.0625f0, RoundNearestTiesAway) === Float8_E4M3(-1.125)
+    @test Float8_E4M3(-1.0625f0, RoundToZero)          === Float8_E4M3(-1.0)
+end
+
+@testset "Unsigned types reject negative inputs in every mode" begin
+    for mode in (RoundNearest, RoundNearestTiesAway, RoundToZero)
+        @test_throws DomainError Float8_E8M0FNU(-1.0f0, mode)
+    end
+end
+
+@testset "Double-rounding regression (Float32 source)" begin
+    # Float32(1.31640625) is strictly above the E4M3 midpoint 1.3125, so direct
+    # rounding lands on 1.375. Double-rounding through an intermediate format
+    # with round-to-even at each stage gives 1.25.
+    @test Float8_E4M3(Float32(1.31640625)) === Float8_E4M3(1.375)
+
+    # nextfloat(1.0078125f0) is strictly above the E1M7 midpoint 1.0078125 of
+    # {1.0, 1.015625}; direct rounding goes up.
+    v = nextfloat(1.0078125f0)
+    @test Float64(_E1M7_FN(v)) == 1.015625
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,6 +56,8 @@ const MX_E8M0 = Float8_E8M0FNU
 @testset "Microfloats" begin
     include("basic.jl")
     include("overflow.jl")
+    include("floatmin.jl")
+    include("rounding_modes.jl")
     include("mx_compliance.jl")
     include("mx_properties.jl")
     include("dlfp8_parity.jl")


### PR DESCRIPTION
- Replace `Number` → `BFloat16` → `Microfloat` intermediate with `Float32`. Fixes a double-rounding bug where `Float8_E4M3(Float32(1.31640625))` produced `1.25` instead of `1.375`.
- Add `T(x, mode::RoundingMode; overflow=...)` supporting `RoundNearest`, `RoundNearestTiesAway`, `RoundToZero`, `RoundFromZero`, `RoundUp`, `RoundDown`. Overflow direction follows IEEE-754 (e.g. `RoundToZero` saturates to ±floatmax even on `OVF`).
- `OVF`/`SAT` are now singleton instances (`Overflowing()` / `Saturating()`) instead of abstract types, dispatched via multiple methods. The `overflow=` keyword can override the per-type default at any call site.
- `floatmin` on degenerate E=1+IEEE formats (no representable normals; smallest-normal bit pattern collides with Inf) now throws `DomainError` instead of returning `Inf`. `floatmax` remains unchanged as it's defined as returning the largest finite number.
- Precision-aware show: per-type 256-entry lookup of shortest-roundtrip decimals built at `@microfloat` expansion. `Float8_E4M3(0.1)` prints as `0.1`, not `0.1015625`.
- Reverse direction (Microfloat → wider float) routes through the lossless `BFloat16` lookup and widens to Float32/Float64/Float16.